### PR TITLE
Do no autoload during compile

### DIFF
--- a/lib/Sniff.ex
+++ b/lib/Sniff.ex
@@ -1,5 +1,6 @@
 defmodule Sniff do
 
+  @compile {:autoload, false}
   @on_load :init
 
   def init() do


### PR DESCRIPTION
We need this flag in order to cross-compile successfully as otherwise there's an attempt to load the sniff.so file during the build process.