### PR TITLE
Ensure project structure after compilation

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,9 @@ defmodule Mix.Tasks.Compile.Nif do
       {:unix, :linux} -> 0 = Mix.Shell.IO.cmd("make -f make.linux")
       {:win32, :nt} -> 0 = Mix.Shell.IO.cmd("nmake /f make.winnt")
     end
-    :ok
+
+    # ensure that generated files are copied to build directory
+    :ok = Mix.Project.build_structure()
   end
 
   def clean() do


### PR DESCRIPTION
After compilation, the generated files might need to be copied into the
target build directory. This is the case if the target directory is not
symlinked. For example, with :build_embedded the priv directory is to be
copied into the build directory. This copy operation usually happens
before the compilers are run. As the NIF compiler generates files, we
need to make sure that those files are present in the target directory
either because they are symlinked, or by making Mix.Project copy them
properly.